### PR TITLE
chore: update pods requests and limits

### DIFF
--- a/.kontinuous/env/dev/values.yaml
+++ b/.kontinuous/env/dev/values.yaml
@@ -1,11 +1,3 @@
-# hasura:
-#   ~needs: [create-db]
-
-# jobs:
-#   runs:
-#     create-db:
-#       use: create-db
-
 deactivate:
   enabled: false
   jobs-deactivate:

--- a/.kontinuous/env/prod/values.yaml
+++ b/.kontinuous/env/prod/values.yaml
@@ -1,0 +1,24 @@
+app:
+  resources:
+    requests:
+      cpu: 5m
+      memory: 128Mi
+    limits:
+      cpu: 10m
+      memory: 256Mi
+  autoscale:
+    enabled: true
+    minReplicas: 2
+
+hasura:
+  resources:
+    requests:
+      cpu: 25m
+      memory: 512Mi
+    limits:
+      cpu: 50m
+      memory: 1024Mi
+  autoscale:
+    enabled: true
+    minReplicas: 2
+

--- a/.kontinuous/values.yaml
+++ b/.kontinuous/values.yaml
@@ -7,16 +7,6 @@ app:
       value: https://{{ .Values.global.host }}
   probesPath: /healthz
   imagePackage: app
-  resources:
-    requests:
-      cpu: 5m
-      memory: 128Mi
-    limits:
-      cpu: 10m
-      memory: 256Mi
-  autoscale:
-    enabled: true
-    minReplicas: 2
 
 hasura:
   ~needs: [create-db]
@@ -27,16 +17,6 @@ hasura:
         name: pg-user
     - configMapRef:
         name: hasura-configmap
-  resources:
-    requests:
-      cpu: 25m
-      memory: 512Mi
-    limits:
-      cpu: 50m
-      memory: 1024Mi
-  autoscale:
-    enabled: true
-    minReplicas: 2
 
 jobs:
   runs:

--- a/.kontinuous/values.yaml
+++ b/.kontinuous/values.yaml
@@ -6,8 +6,17 @@ app:
     - name: NEXTAUTH_URL
       value: https://{{ .Values.global.host }}
   probesPath: /healthz
-  replicas: 2
   imagePackage: app
+  resources:
+    requests:
+      cpu: 5m
+      memory: 128Mi
+    limits:
+      cpu: 10m
+      memory: 256Mi
+  autoscale:
+    enabled: true
+    minReplicas: 2
 
 hasura:
   ~needs: [create-db]
@@ -19,13 +28,15 @@ hasura:
     - configMapRef:
         name: hasura-configmap
   resources:
-    limits:
-      cpu: 500m
-      memory: 1024Mi
     requests:
-      cpu: 250m
+      cpu: 25m
       memory: 512Mi
-  replicas: 2
+    limits:
+      cpu: 50m
+      memory: 1024Mi
+  autoscale:
+    enabled: true
+    minReplicas: 2
 
 jobs:
   runs:


### PR DESCRIPTION
The aim is to to fine tune `app` & `hasura` pods requests and limits on `preprod` and `prod` environments.

![](https://media.giphy.com/media/KyEZaVDr6lFNSMojrx/giphy.gif)

Based on metrics given here:
- [prod](https://grafana.fabrique.social.gouv.fr/d/x9tT8124z/kubernetes-v2-compute-resources-namespace-workloads-pod?orgId=1&refresh=10s&var-datasource=Thanos%20-%20Prod&var-cluster=prod2&var-namespace=secretariat&var-type=deployment&from=now-30d&to=now)
