### PR TITLE
feat: openmetrics

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -31,6 +31,8 @@ fileignoreconfig:
   checksum: b118715f8269bd92790bbe4019159567893d2517cad7ef2a639e456d924b88ca
 - filename: src/hooks/use-onboarding.ts
   checksum: 84ace93b2abe1dbb750a311a6cee984e9b0392be6176871e7e49d7cdf948cef0
+- filename: src/pages/api/openmetrics.ts
+  checksum: bbfd917d0dcc5e53730a48d2c90b1f19b40c49232921208731d0ca556bd11fe1
 - filename: src/services/send-email.ts
   checksum: f8e6673f08300673626ad8ce310cfce4037f5feec086d4ce5808e40c09766992
 - filename: src/services/sync.ts

--- a/src/pages/api/openmetrics.ts
+++ b/src/pages/api/openmetrics.ts
@@ -1,0 +1,78 @@
+import { NextApiRequest, NextApiResponse } from "next"
+import graphQLFetcher from "@/utils/graphql-fetcher"
+
+// return Object.keys but typed from T
+function keysOf<T extends Object>(obj: T): Array<keyof T> {
+  return Array.from(Object.keys(obj)) as any
+}
+
+const queries = {
+  total_user_count: {
+    comment:
+      "# HELP total_user_count Nombre total d'utilisateurs\n" +
+      "# TYPE total_user_count counter",
+    query: `
+query {
+  users_aggregate {
+    aggregate {
+      count
+    }
+  }
+}`,
+  },
+  expired_user_count: {
+    comment:
+      "# HELP expired_user_count Nombre total d'utilisateurs\n" +
+      "# TYPE expired_user_count counter",
+    query: `
+query {
+  users_aggregate(where: {departure: {_lte: "today()"}}) {
+    aggregate {
+      count
+    }
+  }
+}`,
+  },
+  no_expiration_user_count: {
+    comment:
+      "# HELP no_expiration_user_count Nombre total d'utilisateurs sans date d'expiration\n" +
+      "# TYPE no_expiration_user_count counter",
+    query: `
+query {
+  users_aggregate(where: {departure: {_is_null: true}}) {
+    aggregate {
+      count
+    }
+  }
+}`,
+  },
+}
+
+const getMetrics = async () =>
+  Promise.all(
+    keysOf(queries).map(
+      (key) =>
+        graphQLFetcher({
+          query: queries[key].query,
+        }).then((res: any) => ({
+          name: key,
+          value: res?.users_aggregate.aggregate.count,
+          comment: queries[key].comment,
+        })) as Promise<{ name: string; value: number; comment: string }>
+    )
+  )
+
+const OpenMetrics = async (req: NextApiRequest, res: NextApiResponse) => {
+  const metrics = await getMetrics()
+  console.log("metrics", metrics)
+  const text = metrics
+    .map(
+      ({ name, value, comment }) =>
+        `${comment ? comment + "\n" : ""}${name}\t${value}`
+    )
+    .join("\n\n")
+  console.log(text)
+  res.status(200).send(text)
+}
+
+export default OpenMetrics


### PR DESCRIPTION
Ajout d'une route pour remonter des métriques dans grafana

Ce serait intéressant de grapher certaines infos : nb users, nb users actifs...

Ce qu'il manque à cette PR c'est les bons droits pour interroger hasura et remonter les métriques